### PR TITLE
Add unit tests 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/dao/FlashcardDaoTest.java
+++ b/src/test/java/dao/FlashcardDaoTest.java
@@ -13,14 +13,13 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FlashcardDaoTest {
 
-    private IFlashcardDao IFlashcardDao;
+    private IFlashcardDao flashcardDao;
     private Connection connection;
 
     @BeforeAll
     void setupDatabase() throws Exception {
         connection = DriverManager.getConnection(
                 "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL");
-
         ConnectDB.settestConn(connection);
 
         try (Statement statement = connection.createStatement()) {
@@ -44,34 +43,111 @@ class FlashcardDaoTest {
     }
 
     @BeforeEach
-    void setUp() {
-        IFlashcardDao = new FlashcardDao();
-    }
-
-    @AfterEach
-    void cleanUp() throws Exception {
+    void setUp() throws Exception {
+        flashcardDao = new FlashcardDao();
         try (Statement stmt = connection.createStatement()) {
             stmt.execute("TRUNCATE TABLE flashcards");
         }
     }
 
     @Test
-    void testCreateFlashcard() throws Exception {
-        boolean created = IFlashcardDao.createFlashcard(
-                1, "What is an MVC?", "It's a programming model", "Tea", "Candy", "It's a programming model"
+    void testCreateAndGetFlashcard() throws Exception {
+        // Test creation
+        boolean created = flashcardDao.createFlashcard(
+                1, "What is MVC?", "Model View Controller", "Tea", "Candy", "Coffee"
         );
-
         assertTrue(created);
 
-        List<Flashcard> flashcards = IFlashcardDao.getFlashcardsBySetId(1);
+        // Test retrieval
+        List<Flashcard> flashcards = flashcardDao.getFlashcardsBySetId(1);
         assertEquals(1, flashcards.size());
-        assertEquals("What is an MVC?", flashcards.get(0).getQuestion());
+
+        Flashcard flashcard = flashcards.get(0);
+        assertEquals(1, flashcard.getSets_id());
+        assertEquals("What is MVC?", flashcard.getQuestion());
+        assertEquals("Model View Controller", flashcard.getAnswer());
+        assertEquals(0, flashcard.getTimes_answered());
+        assertEquals(0, flashcard.getTimes_correct());
     }
 
     @Test
-    void testGetFlashcardsBySetId_emptyResult() throws Exception {
-        List<Flashcard> flashcards = IFlashcardDao.getFlashcardsBySetId(99);
-        assertNotNull(flashcards);
-        assertTrue(flashcards.isEmpty());
+    void testGetFlashcards_emptyAndMultiple() throws Exception {
+        // Test empty result
+        List<Flashcard> empty = flashcardDao.getFlashcardsBySetId(99);
+        assertTrue(empty.isEmpty());
+
+        // Test multiple flashcards
+        flashcardDao.createFlashcard(1, "Q1", "A1", "C1A", "C1B", "C1C");
+        flashcardDao.createFlashcard(1, "Q2", "A2", "C2A", "C2B", "C2C");
+        flashcardDao.createFlashcard(2, "Q3", "A3", "C3A", "C3B", "C3C");
+
+        assertEquals(2, flashcardDao.getFlashcardsBySetId(1).size());
+        assertEquals(1, flashcardDao.getFlashcardsBySetId(2).size());
+    }
+
+    @Test
+    void testUpdateFlashcard() throws Exception {
+        // Create flashcard
+        flashcardDao.createFlashcard(1, "Original", "Original Answer", "A", "B", "C");
+        int flashcardId = flashcardDao.getFlashcardsBySetId(1).get(0).getFlashcard_id();
+
+        // Test successful update
+        assertTrue(flashcardDao.updateFlashcard(flashcardId, "Updated", "Updated Answer", "UA", "UB", "UC"));
+
+        Flashcard updated = flashcardDao.getFlashcardsBySetId(1).get(0);
+        assertEquals("Updated", updated.getQuestion());
+        assertEquals("Updated Answer", updated.getAnswer());
+
+        // Test update non-existent ID
+        assertFalse(flashcardDao.updateFlashcard(999, "Question", "Answer", "A", "B", "C"));
+    }
+
+    @Test
+    void testDeleteFlashcard() throws Exception {
+        // Create flashcard
+        flashcardDao.createFlashcard(1, "Question", "Answer", "A", "B", "C");
+        int flashcardId = flashcardDao.getFlashcardsBySetId(1).get(0).getFlashcard_id();
+
+        // Test successful deletion
+        assertTrue(flashcardDao.deleteFlashcard(flashcardId));
+        assertTrue(flashcardDao.getFlashcardsBySetId(1).isEmpty());
+
+        // Test delete non-existent ID
+        assertFalse(flashcardDao.deleteFlashcard(999));
+    }
+
+    @Test
+    void testUpdateFlashcardStats() throws Exception {
+        // Create flashcard
+        flashcardDao.createFlashcard(1, "Question", "Answer", "A", "B", "C");
+        int flashcardId = flashcardDao.getFlashcardsBySetId(1).get(0).getFlashcard_id();
+
+        // Test correct answer
+        assertTrue(flashcardDao.updateFlashcardStats(flashcardId, true));
+        Flashcard updated = flashcardDao.getFlashcardsBySetId(1).get(0);
+        assertEquals(1, updated.getTimes_answered());
+        assertEquals(1, updated.getTimes_correct());
+
+        // Test incorrect answer
+        assertTrue(flashcardDao.updateFlashcardStats(flashcardId, false));
+        updated = flashcardDao.getFlashcardsBySetId(1).get(0);
+        assertEquals(2, updated.getTimes_answered());
+        assertEquals(1, updated.getTimes_correct());
+
+        // Test non-existent ID
+        assertFalse(flashcardDao.updateFlashcardStats(999, true));
+    }
+
+    @Test
+    void testEdgeCases() throws Exception {
+        // Test with empty strings
+        assertTrue(flashcardDao.createFlashcard(1, "", "", "", "", ""));
+        assertEquals(1, flashcardDao.getFlashcardsBySetId(1).size());
+
+        // Test with special characters
+        assertTrue(flashcardDao.createFlashcard(2, "What's 2+2?", "It's 4!", "A&B", "<C>", "\"D\""));
+        Flashcard special = flashcardDao.getFlashcardsBySetId(2).get(0);
+        assertEquals("What's 2+2?", special.getQuestion());
+        assertEquals("\"D\"", special.getChoice_c());
     }
 }

--- a/src/test/java/dao/StatisticsDaoTest.java
+++ b/src/test/java/dao/StatisticsDaoTest.java
@@ -1,0 +1,145 @@
+package dao;
+
+import database.ConnectDB;
+import models.Statistics;
+import org.junit.jupiter.api.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StatisticsDaoTest {
+    private static Connection connection;
+    private IStatisticsDao statisticsDao;
+
+    @BeforeAll
+    static void setupDatabase() throws Exception {
+        connection = DriverManager.getConnection("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL");
+        ConnectDB.settestConn(connection);
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE user_accounts (" +
+                    "user_id INT AUTO_INCREMENT PRIMARY KEY," +
+                    "user_name VARCHAR(255) UNIQUE NOT NULL," +
+                    "user_password VARCHAR(255) NOT NULL," +
+                    "role VARCHAR(50) NOT NULL)");
+
+            stmt.execute("CREATE TABLE sets (" +
+                    "sets_id INT AUTO_INCREMENT PRIMARY KEY," +
+                    "user_id INT NOT NULL," +
+                    "description VARCHAR(255) NOT NULL," +
+                    "sets_correct_percentage INT DEFAULT 0," +
+                    "FOREIGN KEY (user_id) REFERENCES user_accounts(user_id))");
+
+            stmt.execute("CREATE TABLE statistics (" +
+                    "stats_id INT AUTO_INCREMENT PRIMARY KEY," +
+                    "user_id INT NOT NULL," +
+                    "sets_id INT NOT NULL," +
+                    "stats_correct_percentage INT DEFAULT 0," +
+                    "FOREIGN KEY (user_id) REFERENCES user_accounts(user_id)," +
+                    "FOREIGN KEY (sets_id) REFERENCES sets(sets_id))");
+        }
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        connection.close();
+    }
+
+    @BeforeEach
+    void setUp() {
+        statisticsDao = new StatisticsDao();
+    }
+
+    @AfterEach
+    void cleanUp() throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("DELETE FROM statistics");
+            stmt.execute("DELETE FROM sets");
+            stmt.execute("DELETE FROM user_accounts");
+        }
+    }
+
+    @Test
+    void testUpsertStatisticsInsert() throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO user_accounts (user_id, user_name, user_password, role) VALUES (1, 'student1', 'pass1', 'student')");
+            stmt.execute("INSERT INTO sets (sets_id, user_id, description) VALUES (1, 1, 'Test Set 1')");
+        }
+
+        assertTrue(statisticsDao.upsertStatistics(1, 1, 85));
+
+        Statistics stats = statisticsDao.getStatistics(1, 1);
+        assertNotNull(stats);
+        assertEquals(1, stats.getUser_id());
+        assertEquals(1, stats.getSets_id());
+        assertEquals(85, stats.getStats_correct_percentage());
+    }
+
+    @Test
+    void testUpsertStatisticsUpdate() throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO user_accounts (user_id, user_name, user_password, role) VALUES (1, 'student1', 'pass1', 'student')");
+            stmt.execute("INSERT INTO sets (sets_id, user_id, description) VALUES (1, 1, 'Test Set 1')");
+        }
+
+        statisticsDao.upsertStatistics(1, 1, 75);
+        assertTrue(statisticsDao.upsertStatistics(1, 1, 90));
+
+        Statistics stats = statisticsDao.getStatistics(1, 1);
+        assertEquals(90, stats.getStats_correct_percentage());
+    }
+
+    @Test
+    void testGetAllStatistics() throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO user_accounts (user_id, user_name, user_password, role) VALUES (1, 'student1', 'pass1', 'student')");
+            stmt.execute("INSERT INTO user_accounts (user_id, user_name, user_password, role) VALUES (2, 'teacher1', 'pass2', 'teacher')");
+            stmt.execute("INSERT INTO sets (sets_id, user_id, description) VALUES (1, 1, 'Test Set 1')");
+            stmt.execute("INSERT INTO sets (sets_id, user_id, description) VALUES (2, 2, 'Test Set 2')");
+        }
+
+        statisticsDao.upsertStatistics(1, 1, 80);
+        statisticsDao.upsertStatistics(2, 2, 75);
+
+        List<Statistics> allStats = statisticsDao.getAllStatistics();
+        assertEquals(2, allStats.size());
+    }
+
+    @Test
+    void testGetStatistics() throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO user_accounts (user_id, user_name, user_password, role) VALUES (1, 'student1', 'pass1', 'student')");
+            stmt.execute("INSERT INTO sets (sets_id, user_id, description) VALUES (1, 1, 'Test Set 1')");
+        }
+
+        statisticsDao.upsertStatistics(1, 1, 85);
+
+        Statistics stats = statisticsDao.getStatistics(1, 1);
+        assertNotNull(stats);
+        assertEquals(85, stats.getStats_correct_percentage());
+
+        assertNull(statisticsDao.getStatistics(999, 999));
+    }
+
+    @Test
+    void testGetStatisticsByUser() throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO user_accounts (user_id, user_name, user_password, role) VALUES (1, 'student1', 'pass1', 'student')");
+            stmt.execute("INSERT INTO sets (sets_id, user_id, description) VALUES (1, 1, 'Test Set 1')");
+            stmt.execute("INSERT INTO sets (sets_id, user_id, description) VALUES (2, 1, 'Test Set 2')");
+        }
+
+        statisticsDao.upsertStatistics(1, 1, 80);
+        statisticsDao.upsertStatistics(1, 2, 90);
+
+        List<Statistics> userStats = statisticsDao.getStatisticsByUser(1);
+        assertEquals(2, userStats.size());
+        assertTrue(userStats.stream().allMatch(s -> s.getUser_id() == 1));
+
+        assertTrue(statisticsDao.getStatisticsByUser(999).isEmpty());
+    }
+}

--- a/src/test/java/dao/UserDaoTest.java
+++ b/src/test/java/dao/UserDaoTest.java
@@ -67,4 +67,17 @@ class UserDaoTest {
         User nonexistent = IUserDao.findByUsername("nonexistent");
         assertNull(nonexistent);
     }
+
+    @Test
+    void testCreateTeacher() throws Exception {
+        boolean created = IUserDao.createTeacher("teacher1", "password123");
+        assertTrue(created);
+
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) AS count FROM user_accounts WHERE user_name='teacher1' AND role='teacher'")) {
+            assertTrue(resultSet.next());
+            assertEquals(1, resultSet.getInt("count"));
+        }
+    }
+
 }

--- a/src/test/java/factory/ServiceFactoryTest.java
+++ b/src/test/java/factory/ServiceFactoryTest.java
@@ -1,0 +1,63 @@
+package factory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import services.*;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ServiceFactoryTest {
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Field instanceField = ServiceFactory.class.getDeclaredField("instance");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+    }
+
+    @Test
+    void testGetInstanceReturnsSameInstance() {
+        ServiceFactory factory1 = ServiceFactory.getInstance();
+        ServiceFactory factory2 = ServiceFactory.getInstance();
+
+        assertSame(factory1, factory2);
+    }
+
+    @Test
+    void testGetFlashcardService() {
+        ServiceFactory factory = ServiceFactory.getInstance();
+        FlashcardService service = factory.getFlashcardService();
+
+        assertNotNull(service);
+        assertSame(service, factory.getFlashcardService());
+    }
+
+    @Test
+    void testGetFlashcardSetService() {
+        ServiceFactory factory = ServiceFactory.getInstance();
+        FlashcardSetService service = factory.getFlashcardSetService();
+
+        assertNotNull(service);
+        assertSame(service, factory.getFlashcardSetService());
+    }
+
+    @Test
+    void testGetUserService() {
+        ServiceFactory factory = ServiceFactory.getInstance();
+        UserService service = factory.getUserService();
+
+        assertNotNull(service);
+        assertSame(service, factory.getUserService());
+    }
+
+    @Test
+    void testGetStatisticsService() {
+        ServiceFactory factory = ServiceFactory.getInstance();
+        StatisticsService service = factory.getStatisticsService();
+
+        assertNotNull(service);
+        assertSame(service, factory.getStatisticsService());
+    }
+}

--- a/src/test/java/models/StatisticsTest.java
+++ b/src/test/java/models/StatisticsTest.java
@@ -1,0 +1,26 @@
+package models;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class StatisticsTest {
+    @Test
+    void testStatisticsGettersAndSetters() {
+        Statistics statistics = new Statistics(1, 100, 5, 85);
+
+        assertEquals(1, statistics.getStats_id());
+        assertEquals(100, statistics.getUser_id());
+        assertEquals(5, statistics.getSets_id());
+        assertEquals(85, statistics.getStats_correct_percentage());
+
+        statistics.setStats_id(2);
+        statistics.setUser_id(200);
+        statistics.setSets_id(10);
+        statistics.setStats_correct_percentage(95);
+
+        assertEquals(2, statistics.getStats_id());
+        assertEquals(200, statistics.getUser_id());
+        assertEquals(10, statistics.getSets_id());
+        assertEquals(95, statistics.getStats_correct_percentage());
+    }
+}

--- a/src/test/java/utils/HashUtilTest.java
+++ b/src/test/java/utils/HashUtilTest.java
@@ -1,0 +1,87 @@
+package utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HashUtilTest {
+
+    // Test successful password hashing
+    @Test
+    void testHashPassword() {
+        String password = "testPassword123";
+
+        String hashedPassword = HashUtil.hashPassword(password);
+
+        assertNotNull(hashedPassword);
+        assertNotEquals(password, hashedPassword);
+        assertTrue(hashedPassword.startsWith("$2a$12$"));
+    }
+
+    // Test that same password produces different hashes (due to salt)
+    @Test
+    void testHashPasswordDifferentSalts() {
+        String password = "testPassword123";
+
+        String hash1 = HashUtil.hashPassword(password);
+        String hash2 = HashUtil.hashPassword(password);
+
+        assertNotEquals(hash1, hash2);
+    }
+
+    // Test password hashing with empty string
+    @Test
+    void testHashPasswordEmpty() {
+        String password = "";
+
+        String hashedPassword = HashUtil.hashPassword(password);
+
+        assertNotNull(hashedPassword);
+        assertTrue(hashedPassword.startsWith("$2a$12$"));
+    }
+
+    // Test successful password verification
+    @Test
+    void testCheckPasswordSuccess() {
+        String password = "testPassword123";
+        String hashedPassword = HashUtil.hashPassword(password);
+
+        boolean result = HashUtil.checkPassword(password, hashedPassword);
+
+        assertTrue(result);
+    }
+
+    // Test password verification with wrong password
+    @Test
+    void testCheckPasswordWrongPassword() {
+        String password = "testPassword123";
+        String wrongPassword = "wrongPassword456";
+        String hashedPassword = HashUtil.hashPassword(password);
+
+        boolean result = HashUtil.checkPassword(wrongPassword, hashedPassword);
+
+        assertFalse(result);
+    }
+
+    // Test password verification with empty password
+    @Test
+    void testCheckPasswordEmptyPlainPassword() {
+        String password = "testPassword123";
+        String hashedPassword = HashUtil.hashPassword(password);
+
+        boolean result = HashUtil.checkPassword("", hashedPassword);
+
+        assertFalse(result);
+    }
+
+    // Test password verification with invalid hash format
+    @Test
+    void testCheckPasswordInvalidHash() {
+        String password = "testPassword123";
+        String invalidHash = "invalidhashformat";
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            HashUtil.checkPassword(password, invalidHash);
+        });
+    }
+}

--- a/src/test/java/utils/HashUtilTest.java
+++ b/src/test/java/utils/HashUtilTest.java
@@ -6,6 +6,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class HashUtilTest {
 
+    // Just to get 100% coverage
+    @Test
+    void testConstructor() {
+        new HashUtil();
+    }
+
     // Test successful password hashing
     @Test
     void testHashPassword() {

--- a/src/test/java/utils/SessionManagerTest.java
+++ b/src/test/java/utils/SessionManagerTest.java
@@ -1,0 +1,97 @@
+package utils;
+
+import models.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SessionManagerTest {
+
+    @BeforeEach
+    void setUp() {
+        // Clear session before each test to ensure clean state
+        SessionManager.clear();
+    }
+
+    // Just to get 100% coverage
+    @Test
+    void testConstructor() {
+        new SessionManager();
+    }
+
+    // Test setting and getting current user
+    @Test
+    void testSetAndGetCurrentUser() {
+        User user = new User(1, "testUser", "password123", "USER");
+
+        SessionManager.setCurrentUser(user);
+        User currentUser = SessionManager.getCurrentUser();
+
+        assertNotNull(currentUser);
+        assertEquals(1, currentUser.getId());
+        assertEquals("testUser", currentUser.getName());
+        assertEquals("password123", currentUser.getPassword());
+        assertEquals("USER", currentUser.getRole());
+        assertSame(user, currentUser);
+    }
+
+    // Test getting current user when none is set
+    @Test
+    void testGetCurrentUserWhenNull() {
+        User currentUser = SessionManager.getCurrentUser();
+
+        assertNull(currentUser);
+    }
+
+    // Test setting current user to null
+    @Test
+    void testSetCurrentUserNull() {
+        SessionManager.setCurrentUser(null);
+        User currentUser = SessionManager.getCurrentUser();
+
+        assertNull(currentUser);
+    }
+
+    // Test clearing current user
+    @Test
+    void testClear() {
+        User user = new User(1, "testUser", "password123", "USER");
+
+        SessionManager.setCurrentUser(user);
+        assertNotNull(SessionManager.getCurrentUser());
+
+        SessionManager.clear();
+        assertNull(SessionManager.getCurrentUser());
+    }
+
+    // Test overwriting current user
+    @Test
+    void testOverwriteCurrentUser() {
+        User user1 = new User(1, "user1", "password1", "USER");
+        User user2 = new User(2, "user2", "password2", "ADMIN");
+
+        SessionManager.setCurrentUser(user1);
+        assertEquals("user1", SessionManager.getCurrentUser().getName());
+
+        SessionManager.setCurrentUser(user2);
+        assertEquals("user2", SessionManager.getCurrentUser().getName());
+        assertEquals(2, SessionManager.getCurrentUser().getId());
+        assertEquals("ADMIN", SessionManager.getCurrentUser().getRole());
+    }
+
+    // Test static behavior across multiple calls
+    @Test
+    void testStaticBehavior() {
+        User user = new User(1, "staticTest", "password123", "USER");
+
+        SessionManager.setCurrentUser(user);
+
+        // Verify the same instance is returned on multiple calls
+        User retrieved1 = SessionManager.getCurrentUser();
+        User retrieved2 = SessionManager.getCurrentUser();
+
+        assertSame(retrieved1, retrieved2);
+        assertSame(user, retrieved1);
+    }
+}

--- a/src/test/java/utils/validation/FlashcardDataTest.java
+++ b/src/test/java/utils/validation/FlashcardDataTest.java
@@ -1,0 +1,41 @@
+package utils.validation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FlashcardDataTest {
+
+    @Test
+    void testConstructorAndGetters() {
+        FlashcardData data = new FlashcardData("What is 2+2?", "4", "3", "4", "5");
+
+        assertEquals("What is 2+2?", data.getQuestion());
+        assertEquals("4", data.getAnswer());
+        assertEquals("3", data.getChoiceA());
+        assertEquals("4", data.getChoiceB());
+        assertEquals("5", data.getChoiceC());
+    }
+
+    @Test
+    void testWithNullValues() {
+        FlashcardData data = new FlashcardData(null, null, null, null, null);
+
+        assertNull(data.getQuestion());
+        assertNull(data.getAnswer());
+        assertNull(data.getChoiceA());
+        assertNull(data.getChoiceB());
+        assertNull(data.getChoiceC());
+    }
+
+    @Test
+    void testWithEmptyStrings() {
+        FlashcardData data = new FlashcardData("", "", "", "", "");
+
+        assertEquals("", data.getQuestion());
+        assertEquals("", data.getAnswer());
+        assertEquals("", data.getChoiceA());
+        assertEquals("", data.getChoiceB());
+        assertEquals("", data.getChoiceC());
+    }
+}

--- a/src/test/java/utils/validation/FlashcardValidatorTest.java
+++ b/src/test/java/utils/validation/FlashcardValidatorTest.java
@@ -1,0 +1,108 @@
+package utils.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FlashcardValidatorTest {
+    private FlashcardValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new FlashcardValidator();
+    }
+
+    @Test
+    void testValidFlashcardData() {
+        FlashcardData validData = new FlashcardData("What is 2+2?", "4", "3", "4", "5");
+
+        assertDoesNotThrow(() -> validator.validate(validData));
+    }
+
+    @Test
+    void testNullQuestion() {
+        FlashcardData data = new FlashcardData(null, "4", "3", "4", "5");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> validator.validate(data));
+        assertEquals("All fields must be filled out", exception.getMessage());
+    }
+
+    @Test
+    void testEmptyQuestion() {
+        FlashcardData data = new FlashcardData("", "4", "3", "4", "5");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> validator.validate(data));
+        assertEquals("All fields must be filled out", exception.getMessage());
+    }
+
+    @Test
+    void testWhitespaceOnlyQuestion() {
+        FlashcardData data = new FlashcardData("   ", "4", "3", "4", "5");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> validator.validate(data));
+        assertEquals("All fields must be filled out", exception.getMessage());
+    }
+
+    @Test
+    void testNullAnswer() {
+        FlashcardData data = new FlashcardData("What is 2+2?", null, "3", "4", "5");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> validator.validate(data));
+        assertEquals("All fields must be filled out", exception.getMessage());
+    }
+
+    @Test
+    void testNullChoiceA() {
+        FlashcardData data = new FlashcardData("What is 2+2?", "4", null, "4", "5");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> validator.validate(data));
+        assertEquals("All fields must be filled out", exception.getMessage());
+    }
+
+    @Test
+    void testNullChoiceB() {
+        FlashcardData data = new FlashcardData("What is 2+2?", "4", "3", null, "5");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> validator.validate(data));
+        assertEquals("All fields must be filled out", exception.getMessage());
+    }
+
+    @Test
+    void testNullChoiceC() {
+        FlashcardData data = new FlashcardData("What is 2+2?", "4", "3", "4", null);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> validator.validate(data));
+        assertEquals("All fields must be filled out", exception.getMessage());
+    }
+
+    @Test
+    void testAnswerDoesNotMatchAnyChoice() {
+        FlashcardData data = new FlashcardData("What is 2+2?", "6", "3", "4", "5");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> validator.validate(data));
+        assertEquals("The answer must match one of the choices", exception.getMessage());
+    }
+
+    @Test
+    void testAnswerMatchesChoiceA() {
+        FlashcardData data = new FlashcardData("What is 2+2?", "3", "3", "4", "5");
+
+        assertDoesNotThrow(() -> validator.validate(data));
+    }
+
+    @Test
+    void testAnswerMatchesChoiceC() {
+        FlashcardData data = new FlashcardData("What is 2+2?", "5", "3", "4", "5");
+
+        assertDoesNotThrow(() -> validator.validate(data));
+    }
+}


### PR DESCRIPTION
Add unit tests for business logic outside of controllers. Controllers need refactoring to extract any business logic from them, so the controllers are as thin as possible. Makes for easier testing.

## Summary by Sourcery

Add comprehensive unit tests for business logic components and bump Java target to version 21

New Features:
- Add unit tests for DAO layer covering FlashcardDao, FlashcardSetDao, UserDao, and StatisticsDao CRUD and business logic

Build:
- Update Maven compiler plugin source and target from Java 1.8 to Java 21

Tests:
- Add unit tests for FlashcardDao, FlashcardSetDao, UserDao, and StatisticsDao validating creation, retrieval, update, deletion, and edge cases
- Add unit tests for FlashcardValidator, SessionManager, and HashUtil covering input validation, session state management, and password hashing/verification
- Add unit tests for ServiceFactory singleton behavior and service retrieval
- Add unit tests for data and model classes (FlashcardData and Statistics) verifying getters, setters, and constructors